### PR TITLE
Add Laravel 10 Support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "php": "^8.0.2",
         "league/flysystem": "^3.2",
         "microsoft/microsoft-graph": "^1.74",
-        "illuminate/support": "^9.0"
+        "illuminate/support": "^9.0,^10.0"
     },
     "scripts": {
         "test": "vendor/bin/phpunit",


### PR DESCRIPTION
The `illuminate/support` dependency was locked to Laravel 9. Allow Laravel 10 in `composer.json`.