### PR TITLE
Fix chunked upload error

### DIFF
--- a/src/OneDriveAdapter.php
+++ b/src/OneDriveAdapter.php
@@ -203,14 +203,10 @@ class OneDriveAdapter extends OneDriveUtilityAdapter implements FilesystemAdapte
             'Content-Length' => strlen($chunk),
         ];
 
-        $response = $http->put(
-            $upload_url,
-            [
-                'headers' => $headers,
-                'body' => $chunk,
-                'timeout' => $this->options['request_timeout'],
-            ]
-        );
+        $response = $http::withHeaders($headers)
+            ->withBody($chunk,'application/octet-stream')
+            ->timeout($this->options['request_timeout'])
+            ->put($upload_url);
 
         if ($response->status() === 404) {
             throw new Exception('Upload URL has expired, please create new upload session');


### PR DESCRIPTION
This pull requests attempts to fix the following issues:  #8 and #9

I replaced the instance call with a static call. This should fix both issues. 

However, after fixing the call to the `put` method, it wasn't working due to the facade attempting to `json_encode` the chunk. 

To work around this issue I applied the headers and the body the way the Http facade requires them to be applied. 

I also had to set the Content-Type application/octet-stream because the Http facade falls back to application/json. 